### PR TITLE
[FLINK-36831][table] Introduce AppendOnlyFirstNFunction in Rank with Async State API

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AbstractAsyncStateTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AbstractAsyncStateTopNFunction.java
@@ -41,11 +41,11 @@ import java.util.Objects;
  *
  * <p>Currently, only constant rank end is supported in async state rank.
  */
-public abstract class AbstractAsyncSyncStateTopNFunction extends AbstractTopNFunction {
+public abstract class AbstractAsyncStateTopNFunction extends AbstractTopNFunction {
 
     private ValueState<Long> rankEndState;
 
-    public AbstractAsyncSyncStateTopNFunction(
+    public AbstractAsyncStateTopNFunction(
             StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             GeneratedRecordComparator generatedSortKeyComparator,
@@ -109,6 +109,14 @@ public abstract class AbstractAsyncSyncStateTopNFunction extends AbstractTopNFun
                                     return rankEndInState;
                                 }
                             });
+        }
+    }
+
+    protected StateFuture<Long> getRankEnd() {
+        if (isConstantRankEnd) {
+            return StateFutureUtils.completedFuture(Objects.requireNonNull(constantRankEnd));
+        } else {
+            return rankEndState.asyncValue();
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateAppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateAppendOnlyTopNFunction.java
@@ -50,7 +50,7 @@ import java.util.List;
  *
  * <p>Different with {@link AppendOnlyTopNFunction}, this function is used with async state api.
  */
-public class AsyncStateAppendOnlyTopNFunction extends AbstractAsyncSyncStateTopNFunction {
+public class AsyncStateAppendOnlyTopNFunction extends AbstractAsyncStateTopNFunction {
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateFastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateFastTop1Function.java
@@ -52,7 +52,7 @@ import org.apache.flink.util.Collector;
  *
  * <p>Different with {@link FastTop1Function}, this function is used with async state api.
  */
-public class AsyncStateFastTop1Function extends AbstractAsyncSyncStateTopNFunction
+public class AsyncStateFastTop1Function extends AbstractAsyncStateTopNFunction
         implements CheckpointedFunction {
 
     private static final long serialVersionUID = 1L;
@@ -117,7 +117,6 @@ public class AsyncStateFastTop1Function extends AbstractAsyncSyncStateTopNFuncti
 
         // load state under current key if necessary
         RowData currentKey = (RowData) keyContext.getCurrentKey();
-
         RowData prevRowFromCache = helper.getPrevRowFromCache(currentKey);
         StateFuture<RowData> prevRowFuture;
         if (prevRowFromCache == null) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/utils/AppendOnlyFirstNHelper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/utils/AppendOnlyFirstNHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.rank.AbstractTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.AppendOnlyFirstNFunction;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AsyncStateAppendOnlyFirstNFunction;
+import org.apache.flink.util.Collector;
+
+/**
+ * A helper to help do the logic 'Top-1' in {@link AppendOnlyFirstNFunction} and {@link
+ * AsyncStateAppendOnlyFirstNFunction}.
+ */
+public class AppendOnlyFirstNHelper extends AbstractTopNFunction.AbstractTopNHelper {
+    public AppendOnlyFirstNHelper(AbstractTopNFunction topNFunction) {
+        super(topNFunction);
+    }
+
+    public void sendData(
+            boolean hasOffset, Collector<RowData> out, RowData inputRow, long rank, long rankEnd) {
+        if (outputRankNumber || hasOffset) {
+            collectInsert(out, inputRow, rank, rankEnd);
+        } else {
+            collectInsert(out, inputRow);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.rank;
 
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AsyncStateAppendOnlyFirstNFunction;
 
 import org.junit.jupiter.api.TestTemplate;
 
@@ -28,7 +29,7 @@ import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
-/** Tests for {@link AppendOnlyFirstNFunction}. */
+/** Tests for {@link AppendOnlyFirstNFunction} and {@link AsyncStateAppendOnlyFirstNFunction}. */
 class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
 
     @Override
@@ -38,20 +39,32 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
             boolean generateUpdateBefore,
             boolean outputRankNumber,
             boolean enableAsyncState) {
-        return new AppendOnlyFirstNFunction(
-                ttlConfig,
-                inputRowType,
-                generatedSortKeyComparator,
-                sortKeySelector,
-                rankType,
-                rankRange,
-                generateUpdateBefore,
-                outputRankNumber);
+        if (enableAsyncState) {
+            return new AsyncStateAppendOnlyFirstNFunction(
+                    ttlConfig,
+                    inputRowType,
+                    generatedSortKeyComparator,
+                    sortKeySelector,
+                    rankType,
+                    rankRange,
+                    generateUpdateBefore,
+                    outputRankNumber);
+        } else {
+            return new AppendOnlyFirstNFunction(
+                    ttlConfig,
+                    inputRowType,
+                    generatedSortKeyComparator,
+                    sortKeySelector,
+                    rankType,
+                    rankRange,
+                    generateUpdateBefore,
+                    outputRankNumber);
+        }
     }
 
     @Override
     boolean supportedAsyncState() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Introduce AppendOnlyFirstNFunction in Rank with Async State API.


## Brief change log

  - *Add AppendOnlyFirstNFunction and AppendOnlyFirstNHelper*
  - *Add AppendOnlyFirstNFunctionTest*


## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)